### PR TITLE
Fix zeitwerk eager-loading

### DIFF
--- a/lib/ocfl.rb
+++ b/lib/ocfl.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "ocfl/version"
 require "zeitwerk"
 require "json"
 require "dry/monads"
@@ -9,17 +8,8 @@ require "dry-struct"
 require "active_support"
 require "active_support/core_ext/module/delegation"
 
-# Custom zeitwerk inflector for OCFL
-class OCFLInflector < Zeitwerk::Inflector
-  def camelize(basename, _abspath)
-    return "OCFL" if basename == "ocfl"
-
-    super
-  end
-end
-
 loader = Zeitwerk::Loader.for_gem
-loader.inflector = OCFLInflector.new
+loader.inflector.inflect("ocfl" => "OCFL")
 loader.setup
 
 module OCFL


### PR DESCRIPTION
This commit fixes a bug that only reared its head in CI within a Rails project: https://github.com/sul-dlss/purl-fetcher/actions/runs/8977705294/job/24656926911?pr=717#step:4:162

Before this change, running the `zeitwerk:check` task in a containing project confirms the problem:

```shell
/path/to/purl-fetcher$ bin/rails zeitwerk:check
Hold on, I am eager loading the application.
bin/rails aborted!
NameError: uninitialized constant OCFL::Version (NameError)

    parent.const_get(cname, false)
          ^^^^^^^^^^
Did you mean?  OCFL::VERSION

Tasks: TOP => zeitwerk:check
(See full trace by running task with --trace)
```

I suspect that replacing the inflector wholesale gets rid of the gem-specific goodies provided by `#for_gem` which includes expecting `lib/{GEM_NAME}/version.rb` to define the `VERSION` constant (vs. the `Version` constant).
