### PR TITLE
Allow overriding the content directory

### DIFF
--- a/lib/ocfl/object/draft_version.rb
+++ b/lib/ocfl/object/draft_version.rb
@@ -81,7 +81,7 @@ module OCFL
       end
 
       def content_path
-        path + "content"
+        path + object_directory.inventory.content_directory
       end
 
       def path

--- a/spec/object/directory_builder_spec.rb
+++ b/spec/object/directory_builder_spec.rb
@@ -16,12 +16,22 @@ RSpec.describe OCFL::Object::DirectoryBuilder do
   let(:object_root) { File.join(@temp_dir, "abc123") }
 
   describe "#save" do
-    it "has built a valid object with a file" do
+    it "builds a valid object with a file" do
       builder.copy_file("Gemfile.lock")
 
       directory = builder.save
       expect(directory).to be_valid
       expect(directory.path("v1", "Gemfile.lock")).to eq Pathname.new(object_root) + "v1/content/Gemfile.lock"
+    end
+  end
+
+  describe "#initialize" do
+    subject(:builder) { described_class.new(object_root:, id: "http://example.com/minimal", content_directory:) }
+
+    let(:content_directory) { "my_documents" }
+
+    it "uses the content_directory param when instantiating an inventory" do
+      expect(builder.object_directory.inventory.content_directory).to eq(content_directory)
     end
   end
 end

--- a/spec/object/draft_version_spec.rb
+++ b/spec/object/draft_version_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe OCFL::Object::DraftVersion do
     let(:new_version) { directory.begin_new_version }
 
     context "with a file in the current directory" do
-      it "has built a valid object" do
+      it "builds a valid object" do
         expect do
           new_version.copy_file("Gemfile.lock")
           new_version.save
@@ -30,12 +30,25 @@ RSpec.describe OCFL::Object::DraftVersion do
     end
 
     context "with a file a sub directory" do
-      it "has built a valid object" do
+      it "builds a valid object" do
         new_version.copy_file("sig/ocfl.rbs")
         new_version.save
         expect(directory).to be_valid
         expect(directory.path("v2", "ocfl.rbs")).to eq Pathname.new(object_root) + "v2/content/ocfl.rbs"
         expect(directory.path(:head, "ocfl.rbs")).to eq Pathname.new(object_root) + "v2/content/ocfl.rbs"
+      end
+    end
+
+    context "when builder is given a content directory" do
+      let(:builder) { OCFL::Object::DirectoryBuilder.new(object_root:, id: "http://example.com/minimal", content_directory:) }
+      let(:content_directory) { "stuff" }
+
+      it "builds a valid object in the expected directory" do
+        new_version.copy_file("sig/ocfl.rbs")
+        new_version.save
+        expect(directory).to be_valid
+        expect(directory.path("v2", "ocfl.rbs")).to eq Pathname.new(object_root) + "v2/#{content_directory}/ocfl.rbs"
+        expect(directory.path(:head, "ocfl.rbs")).to eq Pathname.new(object_root) + "v2/#{content_directory}/ocfl.rbs"
       end
     end
   end
@@ -45,7 +58,7 @@ RSpec.describe OCFL::Object::DraftVersion do
     let(:new_version) { directory.begin_new_version }
 
     context "without a destination path" do
-      it "has built a valid object" do
+      it "builds a valid object" do
         expect do
           new_version.copy_recursive("spec/")
           new_version.save
@@ -59,7 +72,7 @@ RSpec.describe OCFL::Object::DraftVersion do
     end
 
     context "with a destination path" do
-      it "has built a valid object" do
+      it "builds a valid object" do
         expect do
           new_version.copy_recursive("spec/", destination_path: "data/")
           new_version.save


### PR DESCRIPTION
Connects to #17

This commit adds the ability to use a user-provided content directory within each object directory.
