### PR TITLE
Refactor builder

### DIFF
--- a/lib/ocfl/object/directory_builder.rb
+++ b/lib/ocfl/object/directory_builder.rb
@@ -33,12 +33,12 @@ module OCFL
 
       def create_object_directory
         FileUtils.mkdir_p(object_root)
+        FileUtils.touch(object_directory.namaste_file) unless File.exist?(object_directory.namaste_file)
       end
 
       # @return [Directory]
       def save
-        FileUtils.mkdir_p(object_root)
-        FileUtils.touch(object_directory.namaste_file)
+        create_object_directory
         write_inventory
         object_directory
       end


### PR DESCRIPTION
This will allow someone to do
```ruby
builder = OCFL::Object::DirectoryBuilder.new(object_root:, id:)
builder.create_object_directory
version = builder.version
version.save
```

so that they can use a newly created directory/version the same as an existing version.